### PR TITLE
fix(logger): 멀티라인 로그 깨짐, 스킵 목록, 앞공백 우회 수정

### DIFF
--- a/scripts/audit-logger.sh
+++ b/scripts/audit-logger.sh
@@ -47,10 +47,8 @@ case "$TOOL_NAME" in
   Bash)
     CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
     [[ -z "$CMD" ]] && exit 0
-    # Strip leading whitespace to prevent skip pattern bypass
-    CMD=$(echo "$CMD" | sed 's/^[[:space:]]*//')
-    # Flatten multiline commands to single line for log parsing
-    CMD=$(echo "$CMD" | tr '\n' ' ' | sed 's/  */ /g')
+    # Normalize: strip leading whitespace + flatten multiline for skip-pattern matching and log parsing
+    CMD=$(echo "$CMD" | tr '\n' ' ' | sed 's/^[[:space:]]*//; s/  */ /g')
 
     # Always log if command contains file redirects (even if starts with skip pattern)
     HAS_REDIRECT=false

--- a/scripts/audit-logger.sh
+++ b/scripts/audit-logger.sh
@@ -47,6 +47,10 @@ case "$TOOL_NAME" in
   Bash)
     CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
     [[ -z "$CMD" ]] && exit 0
+    # Strip leading whitespace to prevent skip pattern bypass
+    CMD=$(echo "$CMD" | sed 's/^[[:space:]]*//')
+    # Flatten multiline commands to single line for log parsing
+    CMD=$(echo "$CMD" | tr '\n' ' ' | sed 's/  */ /g')
 
     # Always log if command contains file redirects (even if starts with skip pattern)
     HAS_REDIRECT=false
@@ -56,7 +60,7 @@ case "$TOOL_NAME" in
 
     # Skip read-only / exploration commands (unless they redirect to files)
     if [[ "$HAS_REDIRECT" == "false" ]]; then
-      if echo "$CMD" | grep -qE "^(ls|cat |head |tail |less |more |grep |rg |find |echo |printf |pwd|which |type |file |wc |stat |diff |test |\[|true|false|cd |env$|printenv|hostname|uname|date$|whoami|id$|command -v|git (log|status|show|diff|branch|describe|remote -v|rev-parse|config --get|tag -l)|java (-version|--version)|javac |node (-v|--version)|npm (-v|--version|ls|list|view|info|outdated)|command -v|\.\/gradlew (dependencies|tasks|properties|help)|mkdir -p \\\$HOME|mkdir -p ~/|sort |uniq |tr |cut |awk |sed -n|jq )"; then
+      if echo "$CMD" | grep -qE "^(ls|cat |head |tail |less |more |grep |rg |find |echo |printf |pwd|which |type |file |wc |stat |diff |test |\[|true|false|cd |env$|printenv|hostname|uname|date$|whoami|id$|command -v|git (log|status|show|diff|branch|describe|remote -v|rev-parse|config --get|tag -l)|java (-version|--version)|node (-v|--version)|npm (-v|--version|ls|list|view|info|outdated)|\.\/gradlew (dependencies|tasks|properties|help)|sort |uniq |tr |cut |awk |sed -n|jq )"; then
         exit 0
       fi
     fi


### PR DESCRIPTION
## 배경

코드 리뷰에서 도출된 CRITICAL 이슈 2건을 수정합니다.
감사 로거(`audit-logger.sh`)의 Bash 명령 기록 로직에서 로그 정합성과 보안에 직접적인 영향을 주는 버그들입니다.

## 수정 내용

### 1. 멀티라인 Bash 명령 → 로그 포맷 깨짐

- **문제**: heredoc이나 `&&` 개행이 포함된 Bash 명령이 여러 줄로 기록되면, `/audit` 스킬이 `[TIMESTAMP] [TYPE]` 패턴으로 파싱할 때 데이터가 유실됨
- **수정**: 로깅 전에 개행을 공백으로 치환하고 연속 공백 정리
  ```bash
  CMD=$(echo "$CMD" | tr '\n' ' ' | sed 's/^[[:space:]]*//; s/  */ /g')
  ```

### 2. 스킵 목록에서 상태 변경 명령 제거 + 앞공백 우회 차단

- **문제**: `javac`(컴파일러, 파일 생성), `mkdir -p`(디렉토리 생성)가 읽기 전용 스킵 목록에 포함되어 로깅이 누락됨. 명령 앞에 공백이 있으면 스킵 패턴을 우회 가능
- **수정**: 상태 변경 명령 3개 제거 + 중복 `command -v` 패턴 1개 제거 + 앞공백 strip 적용
- **코어 정책**: 로컬에 설치/생성/변경이 발생하면 로깅, 단순 읽기 전용이면 스킵

### 리뷰 피드백 반영

- CMD 정규화 파이프라인 2줄 → 1줄로 병합 (프로세스 스폰 4→3개 감소)

## 영향 범위

- `scripts/audit-logger.sh`의 Bash case 블록만 수정
- Write, Edit 케이스 변경 없음
- 기존 로그 파일에 영향 없음 (새 로그부터 적용)

Fixes #4
Fixes #5