### PR TITLE
feat(marketplace): add marketplace.json so /plugin marketplace add works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "url": "https://github.com/ByeongbumSeo"
   },
   "metadata": {
-    "description": "Marketplace for claude-audit-logger — zero-cost audit trail for Claude Code bypass-permissions mode.",
+    "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs state-changing tool calls with zero token overhead.",
     "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "claude-audit-logger",
-      "source": ".",
+      "source": "./",
       "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
       "version": "1.0.0",
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,34 @@
+{
+  "name": "claude-audit-logger",
+  "owner": {
+    "name": "byeongbumseo",
+    "url": "https://github.com/ByeongbumSeo"
+  },
+  "metadata": {
+    "description": "Marketplace for claude-audit-logger — zero-cost audit trail for Claude Code bypass-permissions mode.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "claude-audit-logger",
+      "source": ".",
+      "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
+      "version": "1.0.0",
+      "author": {
+        "name": "byeongbumseo"
+      },
+      "homepage": "https://github.com/ByeongbumSeo/claude-audit-logger",
+      "repository": "https://github.com/ByeongbumSeo/claude-audit-logger",
+      "license": "MIT",
+      "category": "security",
+      "keywords": [
+        "claude-code",
+        "plugin",
+        "audit",
+        "logging",
+        "bypass-permissions",
+        "security"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` so the install flow documented in the README (`/plugin marketplace add ByeongbumSeo/claude-audit-logger`) succeeds.
- Marketplace manifest references this repo as a single-plugin marketplace (`source: "."`), reusing the existing `plugin.json` at the root.

## Problem
Running the documented command fails:

```
/plugin marketplace add ByeongbumSeo/claude-audit-logger
Error: Marketplace file not found at
  <cache>/marketplaces/ByeongbumSeo-claude-audit-logger/.claude-plugin/marketplace.json
```

Claude Code distinguishes two manifests:

| File | Role | Command |
|------|------|---------|
| `plugin.json` | Single-plugin metadata | `/plugin install` |
| `marketplace.json` | Catalog of one-or-more plugins | `/plugin marketplace add` |

The repo ships only `plugin.json`, so the marketplace loader has nothing to read and bails out. README quick-start therefore breaks for every new user.

## Fix
Add `.claude-plugin/marketplace.json` that exposes the repo as a marketplace with this single plugin (`source: "."`). The existing `plugin.json` is reused as-is — no duplication of metadata.

## Test plan
- [ ] `/plugin marketplace add ByeongbumSeo/claude-audit-logger` completes without error
- [ ] `/plugin install claude-audit-logger@claude-audit-logger` (or equivalent) installs the plugin
- [ ] `/audit` works after restart
- [ ] `jq . .claude-plugin/marketplace.json` parses cleanly