### PR TITLE
feat(plugin): add /audit-doctor skill and /audit diagnostic guidance

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -16,6 +16,26 @@
 
 ## Quick Start
 
+### 사전 준비
+
+이 플러그인은 hook payload 파싱을 위해 `jq`에 의존합니다. **플러그인을 활성화하기 전에 `jq`를 먼저 설치해야 합니다** — `jq`가 없으면 hook 스크립트가 조용히 종료되며 로그도 기록되지 않고 에러도 표시되지 않습니다.
+
+```bash
+# macOS
+brew install jq
+
+# Debian / Ubuntu
+sudo apt install jq
+
+# Fedora / RHEL
+sudo dnf install jq
+
+# Arch
+sudo pacman -S jq
+```
+
+확인: `jq --version`이 버전 정보를 출력하면 정상입니다.
+
 ### 설치
 
 ```bash
@@ -25,6 +45,8 @@
 # 플러그인 설치
 /plugin install claude-audit-logger
 ```
+
+설치 후 **Claude Code를 재시작**하세요. 새 세션에서 `SessionStart` hook이 발화되어야 감사 로그 기록이 시작됩니다.
 
 ### 동작 확인
 
@@ -46,6 +68,7 @@
 | `/audit --success` | 성공한 명령만 |
 | `/audit --fail` | 실패한 명령만 |
 | `/audit session --fail` | 세션 전체 중 실패만 |
+| `/audit-doctor` | 플러그인 헬스 체크 (jq, 훅, 세션, 로그 디렉토리 진단) |
 
 ## 동작 원리
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ When you run Claude Code with `--dangerously-skip-permissions`, every tool call 
 
 ## Quick Start
 
+### Prerequisites
+
+This plugin relies on `jq` to parse hook payloads. **Install `jq` before activating the plugin** — hook scripts exit silently when `jq` is missing, which means no logs are recorded and no error is shown.
+
+```bash
+# macOS
+brew install jq
+
+# Debian / Ubuntu
+sudo apt install jq
+
+# Fedora / RHEL
+sudo dnf install jq
+
+# Arch
+sudo pacman -S jq
+```
+
+Verify: `jq --version` should print a version string.
+
 ### Install
 
 ```bash
@@ -25,6 +45,8 @@ When you run Claude Code with `--dangerously-skip-permissions`, every tool call 
 # Install plugin
 /plugin install claude-audit-logger
 ```
+
+After installing, **restart Claude Code** so the `SessionStart` hook fires in a fresh session.
 
 ### Verify
 
@@ -46,6 +68,7 @@ If you see the command you just executed, it's working.
 | `/audit --success` | Only successful commands |
 | `/audit --fail` | Only failed commands |
 | `/audit session --fail` | Failed commands from entire session |
+| `/audit-doctor` | Diagnose plugin health (jq, hooks, session, log dir) |
 
 ## How it works
 

--- a/skills/audit-doctor/SKILL.md
+++ b/skills/audit-doctor/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: audit-doctor
+description: (claude-audit-logger) Diagnose plugin health. Checks jq installation, hook script files, session environment, and log directory. Use when /audit shows no logs or when troubleshooting why the plugin is not recording commands.
+user_invocable: true
+---
+
+# Audit Doctor
+
+Run health checks on claude-audit-logger plugin installation and surface actionable guidance for common failure modes (missing jq, unregistered hooks, stale session).
+
+## Usage
+
+- `/audit-doctor` - Run all health checks and print a summary with fix suggestions
+
+## Procedure
+
+Run each check with the Bash tool, collect results, then render a single combined report at the end.
+
+### Check 1: jq installation
+
+```bash
+if command -v jq &>/dev/null; then
+  echo "OK: $(jq --version)"
+else
+  echo "FAIL: jq not found in PATH"
+fi
+```
+
+- OK: jq is available
+- FAIL: jq is not installed. This is the most common failure mode - all hook scripts exit silently without jq. Remediation:
+  - macOS: `brew install jq`
+  - Debian/Ubuntu: `sudo apt install jq`
+  - Fedora/RHEL: `sudo dnf install jq`
+  - Arch: `sudo pacman -S jq`
+
+### Check 2: Hook script files
+
+```bash
+find ~/.claude -type f \( -name "audit-session-init.sh" -o -name "audit-task-marker.sh" -o -name "audit-logger.sh" \) 2>/dev/null
+```
+
+Expected: 3 files found, all with executable bit set.
+
+For each file found, also check executability:
+
+```bash
+ls -la <path>
+```
+
+- OK: All 3 scripts present and executable (mode includes `x`)
+- FAIL (missing): Plugin files not installed. Reinstall: `/plugin marketplace add ByeongbumSeo/claude-audit-logger` then `/plugin install claude-audit-logger@claude-audit-logger`
+- FAIL (not executable): `chmod +x <path>`
+
+### Check 3: AUDIT_SESSION_ID environment variable
+
+```bash
+echo "${AUDIT_SESSION_ID:-<empty>}"
+```
+
+- OK: Non-empty UUID-like string - SessionStart hook ran successfully
+- FAIL: Empty - SessionStart hook did not fire in this session. Common causes:
+  - Plugin was installed in the middle of this session - restart Claude Code
+  - jq missing (see Check 1) - SessionStart script exits silently without jq
+  - Hook registration failed - verify Check 2 passes
+
+### Check 4: Log directory
+
+```bash
+if [[ -d ~/.claude/audit-logs ]]; then
+  echo "OK: $(ls -1 ~/.claude/audit-logs | wc -l | tr -d ' ') file(s)"
+else
+  echo "FAIL: ~/.claude/audit-logs does not exist"
+fi
+```
+
+- OK: Directory exists (shows file count)
+- FAIL: Directory missing. Created automatically by the SessionStart hook when it runs correctly.
+
+### Check 5: Current session log file
+
+Only run if Check 3 passed.
+
+```bash
+LOG="$HOME/.claude/audit-logs/${AUDIT_SESSION_ID}.log"
+if [[ -f "$LOG" ]]; then
+  echo "OK: $(wc -l < "$LOG" | tr -d ' ') line(s) in $LOG"
+else
+  echo "FAIL: $LOG does not exist"
+fi
+```
+
+- OK: Current session log exists
+- FAIL: SESSION_ID set but log file missing. Likely the SessionStart hook exited early - check jq (Check 1) and script contents.
+
+### Check 6: jq smoke test
+
+Only run if Check 1 passed. Simulates what the hooks do:
+
+```bash
+echo '{"session_id":"test-123","tool_name":"Bash"}' | jq -r '.session_id'
+```
+
+- OK: Output is `test-123` - jq works correctly with hook input format
+- FAIL: Unexpected output or error - jq is broken (rare; reinstall jq)
+
+## Report format
+
+Combine all check results into a single structured report:
+
+```
+## Claude Audit Logger - Health Check
+
+| # | Check | Status | Detail |
+|---|-------|--------|--------|
+| 1 | jq installation | ✅ / ❌ | <version or error> |
+| 2 | Hook scripts | ✅ / ⚠ / ❌ | <count>/3 found, <count> executable |
+| 3 | AUDIT_SESSION_ID | ✅ / ❌ | <id or 'empty'> |
+| 4 | Log directory | ✅ / ❌ | <file count> |
+| 5 | Current session log | ✅ / ❌ / - | <line count or 'n/a'> |
+| 6 | jq smoke test | ✅ / ❌ / - | <output or skipped> |
+
+### Diagnosis
+
+<One-paragraph summary of the overall state.>
+
+### Actions
+
+<Numbered list of concrete commands to fix each ❌/⚠ item, in priority order. If all checks pass, state "All systems operational. The plugin is working correctly.">
+```
+
+## Prioritization rules
+
+When multiple checks fail, order the fixes this way:
+
+1. Install jq first (Check 1) - fixes most downstream failures
+2. Reinstall plugin or fix file permissions (Check 2) - structural fix
+3. Restart Claude Code (Check 3) - triggers SessionStart hook
+4. Retry `/audit-doctor` to confirm
+
+Do not suggest later fixes before earlier ones are resolved - they may become unnecessary.

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: View audit logs of auto-approved commands (file creates/edits, bash executions) by task, session, or today. Use when you see keywords like 'audit', 'audit log', 'command log', 'what did it do', 'trace log'.
+description: (claude-audit-logger) View audit logs of auto-approved commands (file creates/edits, bash executions) by task, session, or today. Use when you see keywords like 'audit', 'audit log', 'command log', 'what did it do', 'trace log'.
 user_invocable: true
 argument-hint: "[task|session|today] [--success|--fail]"
 ---
@@ -113,6 +113,42 @@ Categorize and display:
 
 ### 6. When no logs exist
 
-- No log file: "Audit log has not been created yet. It will start recording from the next session."
-- Log file exists but no entries: "No important commands recorded. (Exploration commands are not logged)"
-- Filter returns empty: "No commands matching the filter." (e.g., `--fail` but no failures)
+Differentiate between expected-empty states and misconfigurations so users know whether to wait, retry, or fix setup.
+
+**6-a. Filter returned empty (normal)**
+
+The log has entries but the filter excluded all of them.
+
+> "No commands matching the filter." (e.g., `--fail` but no failures)
+
+**6-b. Log file exists but has no entries (normal)**
+
+The session started correctly but no state-changing commands have run yet.
+
+> "No important commands recorded yet. (Read-only/exploration commands are not logged.)"
+
+**6-c. Log file is missing → run a quick diagnosis**
+
+Before showing the generic "log not created" message, check two common misconfigurations and surface actionable guidance.
+
+Run both checks with the Bash tool:
+
+```bash
+# Check 1: is jq installed?
+command -v jq &>/dev/null && echo "jq_ok" || echo "jq_missing"
+
+# Check 2: is the SessionStart hook environment set?
+echo "session_id=${AUDIT_SESSION_ID:-<empty>}"
+```
+
+Then decide what to show:
+
+| jq | AUDIT_SESSION_ID | Message |
+|----|------------------|---------|
+| missing | any | "`jq` is not installed — all hook scripts exit silently without it. Install jq: `brew install jq` (macOS) or `sudo apt install jq` (Linux). Then restart Claude Code." |
+| ok | empty | "The SessionStart hook did not run in this session. This usually happens when the plugin was installed mid-session. Restart Claude Code to trigger initialization." |
+| ok | set | "The SessionStart hook ran but the log file is unexpectedly missing. Run `/audit-doctor` for a full health check." |
+
+Always append a one-line pointer to the full health check skill:
+
+> Run `/audit-doctor` for a comprehensive diagnostic.


### PR DESCRIPTION
## 배경

다른 컴퓨터에 플러그인을 설치한 사용자가 \`/audit\` 실행 시 아무 로그도 나오지 않는 이슈를 겪었고, 원인 진단 과정에서 **\`jq\` 미설치로 모든 hook 스크립트가 조용히 종료되는 것**이 밝혀졌습니다.

근본 문제는 플러그인이 다음 조건에서 아무런 단서도 주지 못한다는 점이었습니다:
- \`jq\`가 설치되어 있지 않음 (모든 hook이 silent exit 0)
- 플러그인 설치 직후 세션에서 SessionStart hook이 발화되지 않음 (재시작 필요)
- 그 외 비정상적인 설치/권한 상태

사용자는 로그가 없을 때 원인을 알 방법이 없어서 문제가 방치되거나 삭제됩니다.

## 변경 내용

### 1. 새 스킬 \`/audit-doctor\` (커밋 1)

플러그인 헬스 체크를 수행하는 별도 진단 스킬을 추가합니다. 6가지 체크:

1. **jq 설치 여부** — 가장 흔한 실패 원인
2. **Hook 스크립트 파일 존재/실행권한** — 재설치 필요 여부 판단
3. **\`AUDIT_SESSION_ID\` 환경변수** — SessionStart hook 발화 여부
4. **로그 디렉토리** — 존재/파일 개수
5. **현재 세션 로그 파일** — 쓰기 중인지 확인
6. **jq smoke test** — hook 입력 포맷 파싱 검증

각 체크는 OK / FAIL 판정과 함께 **구체적 해결 명령**을 출력하며, 복수 실패 시 우선순위(jq → 재설치 → 재시작)대로 안내합니다.

### 2. \`/audit\` 스킬 진단 강화 (커밋 2)

기존 \`/audit\`는 로그가 없을 때 무조건 \"log not created yet\" 만 출력했습니다. 정상 상태(필터 결과 없음, 아직 상태 변경 명령 없음)와 설정 오류를 구분할 수 없었던 문제를 해결합니다.

로그 파일이 없는 경우, \`/audit\`가 간단한 진단(jq + AUDIT_SESSION_ID 체크)을 수행하고 상황별로 다른 메시지를 보여줍니다:

| jq | AUDIT_SESSION_ID | 안내 |
|----|------------------|------|
| 미설치 | any | jq 설치 명령 안내 |
| 설치됨 | 비어있음 | Claude Code 재시작 안내 |
| 설치됨 | 있음 | \`/audit-doctor\` 호출 권장 |

모든 케이스 하단에 \`/audit-doctor\` 포인터를 붙여 심화 진단으로 유도합니다.

또한 OMC 스킬의 관례에 맞춰 \`audit\` / \`audit-doctor\` description 앞에 \`(claude-audit-logger)\` 접두어를 추가해 스킬 목록에서 어느 플러그인 소속인지 식별할 수 있게 했습니다.

### 3. README 개선 (커밋 3)

- **Prerequisites 섹션** 추가 (Quick Start 상단에 배치) — Install 섹션보다 먼저 \`jq\` 설치 명령을 보여주어 사용자가 설치 전에 의존성을 먼저 처리하도록 유도 (macOS/Debian/Fedora/Arch 모두 커버)
- **재시작 안내** 추가 — 설치 직후 열려있던 세션에 hook이 소급 등록되지 않는 동작 명시
- Usage 표에 \`/audit-doctor\` 항목 추가
- EN/KO 동일하게 반영

## 영향 범위

- 신규 파일: \`skills/audit-doctor/SKILL.md\`
- 수정: \`skills/audit/SKILL.md\`, \`README.md\`, \`README.ko.md\`
- hooks 스크립트 변경 없음
- 기존 사용자 동작에 **영향 없음** — 로그 정상 기록 중이던 사용자는 변화를 느끼지 못하고, 문제 있던 사용자만 진단을 보게 됨

## 테스트

- \`/audit-doctor\` 스킬을 로컬 \`~/.claude/skills/audit-doctor/\`에 복사 후 새 세션에서 호출 → 6개 체크 전부 정상 동작 확인
- 정상 상태 케이스의 리포트 출력 형식 검증 완료

## 버전 관리

이 PR에는 버전 bump를 포함하지 않습니다. 누적된 모든 변경(초기 릴리스 이후 버그픽스, marketplace.json 추가, README 개선, 이번 기능 추가)을 하나의 릴리스로 묶어 **별도 PR에서 \`1.1.0\`으로 올릴 예정**입니다.