### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs state-changing tool calls with zero token overhead.",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "claude-audit-logger",
       "source": "./",
       "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "byeongbumseo"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-audit-logger",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
   "author": {
     "name": "byeongbumseo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to claude-audit-logger are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2026-04-20
+
+### Added
+
+- **`/audit-doctor` skill** — comprehensive health check that diagnoses six common failure modes (missing jq, hook script files absent or non-executable, SessionStart hook did not fire, missing log directory, missing current session log, jq parsing smoke test) and surfaces actionable fix commands in priority order.
+- **Diagnostic guidance in `/audit`** — when the log file is missing, `/audit` now runs a quick `jq` + `AUDIT_SESSION_ID` check and shows a specific remediation message (install jq, restart Claude Code, or run `/audit-doctor`) instead of the previous generic "log not created yet" message.
+- **`.claude-plugin/marketplace.json`** — enables `/plugin marketplace add ByeongbumSeo/claude-audit-logger` (the command documented in README) to succeed. Without this file the install flow failed for every new user. (#11)
+- **README Prerequisites section** — `jq` installation commands for macOS/Debian/Fedora/Arch placed above the install step, plus an explicit reminder to restart Claude Code after install so the SessionStart hook fires in a new session.
+- **`/audit` output example** — README now shows what the rendered audit table looks like, complementing the existing raw log format documentation.
+- **`(claude-audit-logger)` description prefix** on all skills so users can identify plugin ownership in the skill list.
+
+### Changed
+
+- **SESSION_ID sanitization** — switched from denylist (`tr -d '/.\\'`) to allowlist (`tr -cd 'a-zA-Z0-9_-'`). The allowlist also blocks spaces, semicolons, null bytes, and other vectors the denylist missed.
+- **Performance**: consolidated three separate `jq` calls into a single `@tsv` invocation in `audit-logger.sh` and `audit-session-init.sh`, reducing subprocess overhead on the hot path.
+- **Refactor**: merged the two CMD normalization passes (leading whitespace strip + multiline flatten) in `audit-logger.sh` into a single `tr | sed` pipeline.
+
+### Fixed
+
+- **Multiline bash commands corrupted the log** (#4) — `heredoc` or `&&` newlines produced multi-line entries that `/audit` could not parse. Commands are now flattened to a single line before logging.
+- **Skip regex allowed state-changing commands** (#5) — `javac` (compiler) and `mkdir -p $HOME` / `mkdir -p ~/` (directory creation) were incorrectly in the read-only skip list and went unrecorded. These have been removed. The duplicate `command -v` entry in the regex has also been cleaned up.
+- **Leading whitespace bypassed skip pattern matching** (#5) — `  rm -rf /` (leading spaces) evaded the `^` anchor. Commands are now stripped of leading whitespace before matching.
+- **`SESSION_ID` was unquoted in env export** (#6) — `echo "export AUDIT_SESSION_ID=$SESSION_ID"` could break on special characters. The value is now double-quoted when written to `CLAUDE_ENV_FILE`.
+- **Missing `jq` caused silent noise instead of graceful exit** (#7) — all three scripts now guard with `command -v jq &>/dev/null || exit 0` before reading stdin, eliminating stderr error spam when `jq` is absent.
+- **`SESSION_ID` path traversal** (#8) — a session ID containing `../` could cause log writes outside `~/.claude/audit-logs/`. Now sanitized (see _Changed_).
+- **Plaintext prompt logging was not disclosed** (#9) — README now notes that task separator lines include up to 100 characters of prompt text, and advises against pasting secrets into prompts.
+- **`marketplace.json` schema** (PR #12 review) — `plugins[0].source` corrected from `"."` to `"./"` which is what the Claude Code schema requires (discovered during local install test).
+
+### Security
+
+- Defense-in-depth against path traversal and shell injection in session ID handling (see _Changed_ and _Fixed_ above).
+
+## [1.0.0] - 2026-04-11
+
+### Added
+
+- Initial release.
+- Four hooks: `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PostToolUseFailure` with zero token overhead.
+- `/audit` skill with task / session / today modes and `--success` / `--fail` filters.
+- Per-session log isolation via `CLAUDE_ENV_FILE`.
+- Automatic cleanup of logs older than 14 days.
+- English and Korean README.
+
+[1.1.0]: https://github.com/ByeongbumSeo/claude-audit-logger/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ByeongbumSeo/claude-audit-logger/releases/tag/v1.0.0


### PR DESCRIPTION
## 개요

초기 1.0.0 이후 누적된 모든 변경사항을 1.1.0으로 묶어 릴리스합니다. 기능 추가와 버그픽스가 많이 누적되었지만 버전을 올리지 않아 기존 사용자가 업데이트를 받을 수 없는 상태였습니다. 이 PR로 해소합니다.

## 포함된 변경

### 신규 기능
- \`/audit-doctor\` 스킬 (6가지 헬스 체크 + 우선순위 기반 복구 안내)
- \`/audit\`에 진단 가이드 내장 (로그 없을 때 jq/세션 확인 후 구체적 해결책 제시)
- \`.claude-plugin/marketplace.json\` 추가로 \`/plugin marketplace add\` 지원
- README Prerequisites 섹션 (jq 설치 가이드)
- \`/audit\` 출력 예시 문서화
- 스킬 description에 \`(claude-audit-logger)\` 접두어

### 버그픽스
- 멀티라인 Bash 명령으로 로그 포맷 깨짐 수정
- 스킵 regex의 상태변경 명령(\`javac\`, \`mkdir -p\`) 제거
- 앞공백으로 스킵 패턴 우회 차단
- \`SESSION_ID\` 따옴표 누락 수정
- \`jq\` 미설치 시 가드 추가 (silent exit)
- \`SESSION_ID\` path traversal 방어 (allowlist)

### 개선
- \`jq\` 호출 3~5회 → 1회 (\`@tsv\`로 통합, 성능 개선)
- CMD 정규화 파이프라인 병합 (프로세스 스폰 감소)

전체 변경 내역은 \`CHANGELOG.md\` 참조.

## 영향 범위

- \`.claude-plugin/plugin.json\`: 1.0.0 → 1.1.0
- \`.claude-plugin/marketplace.json\`: metadata.version + plugins[0].version 모두 1.1.0
- \`CHANGELOG.md\`: 신규 작성

**이 PR 자체는 코드 변경 없음** — 버전 메타데이터 + CHANGELOG만.

## 릴리스 후 작업

머지 후:
1. GitHub Release 생성 + \`v1.1.0\` 태그
2. 릴리스 노트는 CHANGELOG의 1.1.0 섹션 그대로 사용
3. 별도 머신에서 \`claude plugin update claude-audit-logger@claude-audit-logger\` → 재시작 → 동작 확인

## 검증

- \`claude plugin validate\` 통과 ✅
- 버전 3곳 모두 1.1.0 일치 ✅