### PR TITLE
fix(hooks): UserPromptSubmit reads .prompt instead of .message.content

### DIFF
--- a/scripts/audit-task-marker.sh
+++ b/scripts/audit-task-marker.sh
@@ -21,16 +21,8 @@ if [[ ! -f "$LOG_FILE" ]]; then
   exit 0
 fi
 
-# Extract user message (handle both string and array content)
-CONTENT=$(echo "$INPUT" | jq -r '
-  if .message.content | type == "string" then
-    .message.content
-  elif .message.content | type == "array" then
-    [.message.content[] | select(.type == "text") | .text] | join(" ")
-  else
-    ""
-  end
-' 2>/dev/null)
+# Extract user prompt text (UserPromptSubmit payload: top-level .prompt)
+CONTENT=$(echo "$INPUT" | jq -r '.prompt // ""')
 
 # Truncate to 100 chars for readability
 if [[ ${#CONTENT} -gt 100 ]]; then

--- a/scripts/audit-task-marker.sh
+++ b/scripts/audit-task-marker.sh
@@ -21,8 +21,14 @@ if [[ ! -f "$LOG_FILE" ]]; then
   exit 0
 fi
 
-# Extract user prompt text (UserPromptSubmit payload: top-level .prompt)
-CONTENT=$(echo "$INPUT" | jq -r '.prompt // ""')
+# Extract user prompt text (UserPromptSubmit payload: top-level .prompt is a string).
+# Type guard: non-strings (int/bool) collapse to "" so the length check below skips them.
+CONTENT=$(echo "$INPUT" | jq -r '.prompt | if type == "string" then . else "" end')
+
+# Flatten newlines/carriage returns so the "=== ... ===" separator stays on a single log line.
+# Without this, a multi-line prompt (e.g. pasted code) splits the separator across multiple
+# lines and breaks /audit task-mode boundary detection.
+CONTENT=$(echo "$CONTENT" | tr '\n\r' ' ')
 
 # Truncate to 100 chars for readability
 if [[ ${#CONTENT} -gt 100 ]]; then


### PR DESCRIPTION
## Summary

`scripts/audit-task-marker.sh` 의 `UserPromptSubmit` hook이 프롬프트 텍스트를 `.message.content` 에서 읽고 있었으나, Claude Code의 실제 페이로드는 최상위 `.prompt` (string)에 프롬프트를 담는다. 결과적으로 `CONTENT` 가 항상 빈 문자열이 되어 `${#CONTENT} -lt 2` 가드에 걸려 조용히 exit → `=== ... ===` 작업 구분선이 감사 로그에 기록되지 않았다.

## Changes

- jq 추출 로직을 `.prompt // ""` 로 단순화
- schema mismatch를 가려오던 `2>/dev/null` 제거
- 주석을 현실화 (단일 string 필드임을 명시)

변경 범위:

```
scripts/audit-task-marker.sh | 12 ++----------
1 file changed, 2 insertions(+), 10 deletions(-)
```

## Test plan

- [x] Smoke test: 가짜 payload (`{"session_id":"test","prompt":"hello world"}`)를 파이프 → 로그 파일에 `=== [timestamp] hello world ===` 줄 생성 확인
- [ ] 릴리스 후 플러그인 재설치 → 실 세션에서 `/audit session` 실행 → 작업 구분선 등장 확인

Closes #15
