### PR TITLE
fix(skills): remove duplicate (claude-audit-logger) prefix from descriptions

### DIFF
--- a/skills/audit-doctor/SKILL.md
+++ b/skills/audit-doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-doctor
-description: (claude-audit-logger) Diagnose plugin health. Checks jq installation, hook script files, session environment, and log directory. Use when /audit shows no logs or when troubleshooting why the plugin is not recording commands.
+description: Diagnose plugin health. Checks jq installation, hook script files, session environment, and log directory. Use when /audit shows no logs or when troubleshooting why the plugin is not recording commands.
 user_invocable: true
 ---
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: (claude-audit-logger) View audit logs of auto-approved commands (file creates/edits, bash executions) by task, session, or today. Use when you see keywords like 'audit', 'audit log', 'command log', 'what did it do', 'trace log'.
+description: View audit logs of auto-approved commands (file creates/edits, bash executions) by task, session, or today. Use when you see keywords like 'audit', 'audit log', 'command log', 'what did it do', 'trace log'.
 user_invocable: true
 argument-hint: "[task|session|today] [--success|--fail]"
 ---


### PR DESCRIPTION
## Summary

Claude Code는 플러그인 소유 스킬을 슬래시 메뉴에 표시할 때 자동으로 `(<plugin-name>)` prefix를 붙인다. 그런데 1.1.0에서 `SKILL.md` `description:` 필드에도 수동으로 동일한 prefix를 추가해뒀기 때문에 `(claude-audit-logger) (claude-audit-logger) ...` 처럼 중복 출력되고 있었다.

## Changes

- `skills/audit/SKILL.md`: `description:` 선두 `(claude-audit-logger) ` 제거
- `skills/audit-doctor/SKILL.md`: 동일

변경 범위:

```
skills/audit-doctor/SKILL.md | 2 +-
skills/audit/SKILL.md        | 2 +-
2 files changed, 2 insertions(+), 2 deletions(-)
```

## Test plan

- [ ] 릴리스 후 플러그인 재설치 → 슬래시 메뉴에서 `/audit`, `/audit-doctor` 항목이 단일 `(claude-audit-logger)` prefix 로만 표시되는지 확인

## Note

기능 영향 없음 (cosmetic). 1.1.0 CHANGELOG에 의도적 feature로 적혀 있던 prefix 추가를 되돌리는 성격이라, 1.1.1 CHANGELOG에 그 맥락을 함께 기재 예정.

Closes #16
