### PR TITLE
chore(release): 1.1.1 — UserPromptSubmit payload fix + skill prefix dedup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs state-changing tool calls with zero token overhead.",
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "plugins": [
     {
       "name": "claude-audit-logger",
       "source": "./",
       "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "byeongbumseo"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-audit-logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
   "author": {
     "name": "byeongbumseo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to claude-audit-logger are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-04-21
+
+### Fixed
+
+- **`UserPromptSubmit` hook read the wrong payload field** (#15) — `scripts/audit-task-marker.sh` extracted the user prompt from `.message.content`, but Claude Code's actual `UserPromptSubmit` payload places the prompt at top-level `.prompt` (string). `CONTENT` was always empty, the length-2 guard tripped, and the script silently exited without writing the `=== ... ===` task separator. `/audit` task mode was effectively non-functional since 1.0.0. Now reads `.prompt` directly and drops the `2>/dev/null` that masked the silent schema mismatch.
+- **Multi-line prompts split the task separator across log lines** — surfaced as a follow-up after the `.prompt` fix above made `CONTENT` non-empty for the first time. A pasted multi-line prompt produced `=== [ts] line1\nline2 ===` rendered as two log lines, which broke `/audit` task-mode boundary detection. Embedded newlines and carriage returns now collapse to spaces before the line is written.
+- **Non-string `.prompt` produced fake separators** — defensive guard surfaced in pre-merge review. If Claude Code ever sends `.prompt` as an integer or boolean, `jq -r` coerces it to its string form (`"42"`, `"true"`) which passes the length-2 guard and writes a misleading separator. A jq type guard now collapses non-strings to `""`.
+
+### Removed
+
+- **Manual `(claude-audit-logger)` description prefix on plugin skills** (#16) — added in 1.1.0 so users could identify plugin ownership in the skill list, but Claude Code already prepends the plugin name automatically for plugin-owned skills, producing duplicate prefixes (`(claude-audit-logger) (claude-audit-logger) ...`) in the slash menu. The manual prefix has been removed from `skills/audit/SKILL.md` and `skills/audit-doctor/SKILL.md`.
+
 ## [1.1.0] - 2026-04-20
 
 ### Added
@@ -48,5 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic cleanup of logs older than 14 days.
 - English and Korean README.
 
+[1.1.1]: https://github.com/ByeongbumSeo/claude-audit-logger/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/ByeongbumSeo/claude-audit-logger/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ByeongbumSeo/claude-audit-logger/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

1.1.0 직후 발견된 두 결함을 묶은 패치 릴리스. 깨진 부분만 손대고 새 기능은 없음.

- **#15** `UserPromptSubmit` hook이 잘못된 jq 경로(`.message.content` vs `.prompt`)를 읽어 작업 구분선이 한 줄도 기록되지 않던 결함을 수정. pre-merge 리뷰에서 발견된 multiline payload 처리 + non-string type guard 까지 함께 포함 (PR #17).
- **#16** 1.1.0에서 도입한 수동 `(claude-audit-logger)` description prefix 제거. Claude Code가 플러그인 스킬에 자동으로 같은 prefix를 붙여서 슬래시 메뉴에 중복 표시되던 문제 (PR #18).

## What's in this PR

- `.claude-plugin/plugin.json`: `1.1.0` → `1.1.1`
- `.claude-plugin/marketplace.json`: `metadata.version` + `plugins[0].version` 모두 `1.1.0` → `1.1.1`
- `CHANGELOG.md`: `[1.1.1] - 2026-04-21` 섹션 추가 (Fixed × 3, Removed × 1) + compare 링크

코드 변경은 이미 main에 머지됨 (#17, #18). 이 PR은 버전/CHANGELOG 동기화만 담당.

## Test plan

- [x] `claude plugin validate` ✅
- [ ] 머지 후 `/plugin install claude-audit-logger@claude-audit-logger` 재설치 → 새 세션에서:
  - [ ] `/audit-doctor` 6/6 ✅
  - [ ] 짧은 프롬프트 입력 → `/audit session` 으로 `=== [...] ===` 구분선 등장 확인
  - [ ] 멀티라인 프롬프트(코드 붙여넣기) → 구분선 1줄로 기록되는지 확인
  - [ ] 슬래시 메뉴에서 `/audit`, `/audit-doctor` 가 단일 `(claude-audit-logger)` prefix 로만 표시되는지 확인

Refs #15, #16
