### PR TITLE
fix(hooks): skip separator for /audit invocations to preserve task boundary

### DIFF
--- a/scripts/audit-task-marker.sh
+++ b/scripts/audit-task-marker.sh
@@ -30,6 +30,13 @@ CONTENT=$(echo "$INPUT" | jq -r '.prompt | if type == "string" then . else "" en
 # lines and breaks /audit task-mode boundary detection.
 CONTENT=$(echo "$CONTENT" | tr '\n\r' ' ')
 
+# Skip separator writing for audit meta-skill invocations.
+# /audit and /audit-doctor are read-only view skills; if we wrote a separator for them,
+# `/audit task` would treat its own invocation as the task boundary and always return empty.
+if [[ "$CONTENT" =~ ^/(claude-audit-logger:)?audit(-doctor)?([[:space:]]|$) ]]; then
+  exit 0
+fi
+
 # Truncate to 100 chars for readability
 if [[ ${#CONTENT} -gt 100 ]]; then
   CONTENT="${CONTENT:0:100}..."


### PR DESCRIPTION
## Summary

`/audit` 호출이 자기 자신을 task 경계로 삼아 `/audit task` 결과가 항상 비어있던 버그 수정. 1.1.1 에서 separator 가 정상 기록되기 시작하면서 드러난 regression.

Closes #20

## Changes

- `scripts/audit-task-marker.sh`: `.prompt` 가 audit 계열 메타 스킬 호출 패턴(`^/(claude-audit-logger:)?audit(-doctor)?(\s|$)`)이면 separator 를 쓰지 않고 조기 종료.
- 매칭 대상: `/audit`, `/audit task|session|today`, `/audit --success|--fail`, `/audit-doctor`, `/claude-audit-logger:audit` 및 그 인자 조합.

### 대안 비교 요지

| | A(채택) 훅 필터 | B 스킬 walk-back |
|---|---|---|
| 코드량 | 4줄 | 20+줄 (루프 + EOF 경계 + 패턴) |
| 연속 `/audit` | 자연스럽게 해결 | walk-back 루프 필요 |
| 원칙 | read-only 메타 스킬 skip — `audit-logger.sh` 가 `ls`/`grep` 등 read-only bash 를 걸러내는 것과 같은 결 | 뷰 레이어에서 필터링 |

A 안이 "read-only 스킬은 훅에서 skip" 이라는 기존 원칙과 일관되고, 연속 호출 엣지 케이스도 자동으로 해결되므로 채택.

## Test plan

- [x] 훅 단위 regex 검증: `/audit`, `/audit task`, `/audit-doctor`, `/claude-audit-logger:audit`, `/claude-audit-logger:audit-doctor` 8종 → skip. 실제 사용자 프롬프트(`docs 정리해줘`, `/help`, `/auditorium`, `audit log 고쳐줘` 등) 6종 → write. 14/14 pass.
- [x] End-to-end: 임시 `HOME` 으로 훅을 실제 invoke 해서 6개 프롬프트(일반 × 3 + /audit 계열 × 2 + 멀티라인 × 1) 통과 확인. 로그에 `=== /audit ... ===` separator 없음, 멀티라인은 단일 라인으로 flatten.
- [ ] 머지 후 실제 세션에서 `rm` → `/audit task` 로 방금 `rm` 이 보이는지 확인.
- [ ] `/audit` 연속 2회 호출 시 직전 task 가 동일하게 보이는지 확인.