### PR TITLE
chore(release): 1.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs state-changing tool calls with zero token overhead.",
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "plugins": [
     {
       "name": "claude-audit-logger",
       "source": "./",
       "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "byeongbumseo"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-audit-logger",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Zero-cost audit trail for Claude Code bypass-permissions mode. Logs every state-changing tool call with zero token overhead.",
   "author": {
     "name": "byeongbumseo"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to claude-audit-logger are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-04-21
+
+### Fixed
+
+- **`/audit task` was permanently empty after 1.1.1** (#20) — `scripts/audit-task-marker.sh` wrote a `=== [ts] /audit ... ===` separator for every `UserPromptSubmit`, including invocations of `/audit` itself. Since `/audit task` is defined as "entries after the last separator", the skill always observed its own invocation as the task boundary and returned an empty result. The prior `.message.content` bug in 1.1.0 masked this because no separators were written at all — task mode effectively showed the whole session. The hook now skips separator writing when `.prompt` matches `^/(claude-audit-logger:)?audit(-doctor)?(\s|$)`, so the previous real user task remains the nearest boundary. Consecutive `/audit` calls also behave correctly (each one shows the same preceding task instead of an empty window).
+
 ## [1.1.1] - 2026-04-21
 
 ### Fixed
@@ -60,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic cleanup of logs older than 14 days.
 - English and Korean README.
 
+[1.1.2]: https://github.com/ByeongbumSeo/claude-audit-logger/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/ByeongbumSeo/claude-audit-logger/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/ByeongbumSeo/claude-audit-logger/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/ByeongbumSeo/claude-audit-logger/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

1.1.2 patch 릴리스. 1.1.1 에서 `UserPromptSubmit` separator 가 정상 동작하기 시작하면서 드러난 `/audit task` self-boundary 버그를 수정.

## Changes

- `.claude-plugin/plugin.json`: version 1.1.1 → 1.1.2
- `.claude-plugin/marketplace.json`: metadata.version + plugins[0].version 1.1.1 → 1.1.2
- `CHANGELOG.md`: [1.1.2] Fixed 섹션 + compare link 추가

### Included

- #21 (fix #20): `/audit` 계열 메타 스킬 호출 시 separator 작성 skip

## Test plan

- [x] `/audit task` self-boundary 수정 — 훅 단위 regex 14/14 + E2E 6 프롬프트 모두 통과 (#21 참고)
- [ ] 머지 + tag + release 발행 후 `/plugin` 으로 1.1.2 업데이트 → 실제 세션에서 `rm` → `/audit task` 로 동작 확인